### PR TITLE
fix ReadUntil timeout; fix ReadUntil from Windows client

### DIFF
--- a/lib/context/client.go
+++ b/lib/context/client.go
@@ -75,6 +75,9 @@ func (c *TCPClient) ReadUntilClean(token string) string {
 }
 
 func (c *TCPClient) ReadUntil(token string) string {
+    // Set read time out
+	c.Conn.SetReadDeadline(time.Now().Add(time.Second * 3))
+    
 	inputBuffer := make([]byte, 1)
 	var outputBuffer bytes.Buffer
 	for {
@@ -82,10 +85,15 @@ func (c *TCPClient) ReadUntil(token string) string {
 		n, err := c.Conn.Read(inputBuffer)
 		c.ReadLock.Unlock()
 		if err != nil {
-			log.Error("Read from client failed")
-			c.Interactive = false
-			Ctx.DeleteTCPClient(c)
-			return outputBuffer.String()
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				log.Error("Read response timeout from client")
+			} else {
+				log.Error("Read from client failed")
+				c.Interactive = false
+				Ctx.DeleteTCPClient(c)
+				return outputBuffer.String()
+			}
+			break
 		}
 		outputBuffer.Write(inputBuffer[:n])
 		// If found token, then finish reading
@@ -196,6 +204,10 @@ func (c *TCPClient) SystemToken(command string) string {
 	input := "echo " + tokenA + " && " + command + "; echo " + tokenB
 	log.Info("Executing: %s", input)
 	c.System(input)
+    
+    // For Windows client
+    // c.ReadUntil(tokenA + " \r\n")
+    // For Linux client
 	c.ReadUntil(tokenA + "\n")
 	output := c.ReadUntil(tokenB)
 	result := strings.Split(output, tokenB)[0]


### PR DESCRIPTION
+ ReadUntil function will wait forever if client's socket is broken, so need to set a read deadline

+ While reading from a Windows client, ReadUntil function will never return. Because of:
  ```
  // For Windows client
  input := "echo " + tokenA + " && " + command + " & echo " + tokenB
  c.ReadUntil(tokenA + "\n")

  C:\>echo 123| xxd
  00000000: 3132 330d 0a                             123..

  C:\>echo 123 | xxd
  00000000: 3132 3320 0d0a                           123 ..

  $ echo 123| xxd
  00000000: 3132 330a                                123.

  $ echo 123 | xxd
  00000000: 3132 330a                                123.
  ```