### PR TITLE
add command `Delete`

### DIFF
--- a/lib/cli/dispatcher/delete.go
+++ b/lib/cli/dispatcher/delete.go
@@ -1,0 +1,43 @@
+package dispatcher
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/WangYihang/Platypus/lib/context"
+	"github.com/WangYihang/Platypus/lib/util/log"
+)
+
+func (dispatcher Dispatcher) Delete(args []string) {
+	if len(args) != 1 {
+		log.Error("Arguments error, use `Help Delete` to get more information")
+		dispatcher.DeleteHelp([]string{})
+		return
+	}
+	for _, server := range context.Ctx.Servers {
+		if strings.HasPrefix(server.Hash(), strings.ToLower(args[0])) {
+			context.Ctx.DeleteServer(server)
+			log.Success("Delete server node [%s]", server.Hash())
+			return
+		}
+		for _, client := range (*server).GetAllTCPClients() {
+			if strings.HasPrefix(client.Hash, strings.ToLower(args[0])) {
+				context.Ctx.DeleteTCPClient(client)
+				log.Success("Delete client node [%s]", client.Hash)
+				return
+			}
+		}
+	}
+	log.Error("No such node")
+}
+
+func (dispatcher Dispatcher) DeleteHelp(args []string) {
+	fmt.Println("Usage of Delete")
+	fmt.Println("\tDelete [HASH]")
+	fmt.Println("\tHASH\tThe hash of an node, node can be both a server or a client")
+}
+
+func (dispatcher Dispatcher) DeleteDesc(args []string) {
+	fmt.Println("Delete")
+	fmt.Println("\tDelete a node, node can be both a server or a client")
+}


### PR DESCRIPTION
make sure it could goto next loop then call `listener.Close` immediately, instead of being blocked in `listener.Accept`. But this implementation may not be elegant enough😂

```go
// Connect to the listener, in order to call listener.Close() immediately
go func() {
	tmp, _ := net.Dial("tcp", fmt.Sprintf("%s:%d", s.Host, s.Port))
	if tmp != nil {
		tmp.Close()
	}
}()
```

p.s. Thanks for your code, I was able to use it for persistent permissions in a recent AWD😁