### PR TITLE
change port to unsigned integer to support high ports

### DIFF
--- a/lib/cli/dispatcher/run.go
+++ b/lib/cli/dispatcher/run.go
@@ -16,14 +16,14 @@ func (dispatcher Dispatcher) Run(args []string) {
 	}
 
 	host := args[0]
-	port, err := strconv.ParseInt(args[1], 10, 32)
+	port, err := strconv.ParseUint(args[1], 10, 32)
 	if err != nil {
 		log.Error("Invalid port: %s, use `Help Run` to get more information", args[1])
 		dispatcher.RunHelp([]string{})
 		return
 	}
 
-	server := context.CreateTCPServer(host, int16(port))
+	server := context.CreateTCPServer(host, uint16(port))
 	go (*server).Run()
 	context.Ctx.AddServer(server)
 }

--- a/lib/cli/dispatcher/run.go
+++ b/lib/cli/dispatcher/run.go
@@ -16,7 +16,7 @@ func (dispatcher Dispatcher) Run(args []string) {
 	}
 
 	host := args[0]
-	port, err := strconv.ParseUint(args[1], 10, 32)
+	port, err := strconv.ParseUint(args[1], 10, 16)
 	if err != nil {
 		log.Error("Invalid port: %s, use `Help Run` to get more information", args[1])
 		dispatcher.RunHelp([]string{})

--- a/lib/context/server.go
+++ b/lib/context/server.go
@@ -17,13 +17,13 @@ import (
 
 type TCPServer struct {
 	Host      string
-	Port      int16
+	Port      uint16
 	Clients   map[string](*TCPClient)
 	TimeStamp time.Time
 	Stopped   chan struct{}
 }
 
-func CreateTCPServer(host string, port int16) *TCPServer {
+func CreateTCPServer(host string, port uint16) *TCPServer {
 	return &TCPServer{
 		Host:      host,
 		Port:      port,
@@ -52,7 +52,7 @@ func GetHostname(host string) string {
 	return strings.Split(host, ":")[0]
 }
 
-func GetPort(host string, default_port int16) int16 {
+func GetPort(host string, default_port uint16) uint16 {
 	pair := strings.Split(host, ":")
 	if len(pair) < 2 {
 		return default_port
@@ -61,7 +61,7 @@ func GetPort(host string, default_port int16) int16 {
 	if err != nil {
 		return default_port
 	}
-	return int16(port)
+	return uint16(port)
 }
 
 func (s *TCPServer) Run() {


### PR DESCRIPTION
Hi,

I often run my reverse shells on high ports and noticed that when I run on a port like 33333 it overflows and tries to open a port on a negative integer which of course doesn't work.

Fix is to change the port variable to an unsigned integer, and parse the input to the Run command as such. I have it working on my machine and it's a trivial patch so I'll submit a PR, but I've never written in Go before so.. you know.. watch out I guess. I'm not sure if this needs to be patched elsewhere in the project, but I did a search and couldn't see any more changes to make.

I've only just started using Platypus a few minutes ago but it's looking really nice. Appreciate your work on the project.