### PR TITLE
Remove duplicate check

### DIFF
--- a/internal/context/server.go
+++ b/internal/context/server.go
@@ -185,11 +185,6 @@ func (s *TCPServer) Handle(conn net.Conn) {
 func (s *TCPServer) Run() {
 	service := fmt.Sprintf("%s:%d", s.Host, s.Port)
 	tcpAddr, err := net.ResolveTCPAddr("tcp4", service)
-	if err != nil {
-		log.Error("Resolve TCP address failed: %s", err)
-		Ctx.DeleteServer(s)
-		return
-	}
 
 	var listener net.Listener
 	if s.Encrypted {


### PR DESCRIPTION
在 CreateTCPServer 方法中已经检查过一次了，没必要在 Run 方法中再检查一次，所以我删除了第二次异常处理的代码，其实更好的方式是直接把 tcpAddr 作为 TCPServer 结构体的一员。