### PR TITLE
Add DataDispatcher support for Termite clients

### DIFF
--- a/internal/cli/dispatcher/data_dispatcher.go
+++ b/internal/cli/dispatcher/data_dispatcher.go
@@ -30,6 +30,15 @@ func (dispatcher commandDispatcher) DataDispatcher(args []string) {
 				n++
 			}
 		}
+
+		for _, client := range (*server).GetAllTermiteClients() {
+			if client.GroupDispatch {
+				log.Info("Executing on %s: %s", client.FullDesc(), command)
+				result := client.System(command)
+				log.Success("%s", result)
+				n++
+			}
+		}
 	}
 	log.Success("Execution finished, %d node DataDispatcherd", n)
 }

--- a/internal/cli/dispatcher/switching.go
+++ b/internal/cli/dispatcher/switching.go
@@ -25,6 +25,10 @@ func (dispatcher commandDispatcher) Switching(args []string) {
 				client.GroupDispatch = server.GroupDispatch
 				log.Success("[%t->%t] %s", !client.GroupDispatch, client.GroupDispatch, client.FullDesc())
 			}
+			for _, client := range (*server).GetAllTermiteClients() {
+				client.GroupDispatch = server.GroupDispatch
+				log.Success("[%t->%t] %s", !client.GroupDispatch, client.GroupDispatch, client.FullDesc())
+			}
 			return
 		}
 	}
@@ -32,6 +36,13 @@ func (dispatcher commandDispatcher) Switching(args []string) {
 	// handle the hash represent a client
 	for _, server := range context.Ctx.Servers {
 		for _, client := range (*server).GetAllTCPClients() {
+			if strings.HasPrefix(client.Hash, strings.ToLower(args[0])) {
+				client.GroupDispatch = !client.GroupDispatch
+				log.Success("[%t->%t] %s", !client.GroupDispatch, client.GroupDispatch, client.FullDesc())
+				return
+			}
+		}
+		for _, client := range (*server).GetAllTermiteClients() {
 			if strings.HasPrefix(client.Hash, strings.ToLower(args[0])) {
 				client.GroupDispatch = !client.GroupDispatch
 				log.Success("[%t->%t] %s", !client.GroupDispatch, client.GroupDispatch, client.FullDesc())

--- a/internal/cli/dispatcher/turn.go
+++ b/internal/cli/dispatcher/turn.go
@@ -36,16 +36,16 @@ func (dispatcher commandDispatcher) Turn(args []string) {
 	if client != nil {
 		client.GroupDispatch = !client.GroupDispatch
 		log.Success("[%t->%t] %s", !client.GroupDispatch, client.GroupDispatch, client.FullDesc())
-	}
-
-	// handle the hash represent a termite client
-	termiteclient := context.Ctx.FindTermiteClientByHash(hash)
-	if termiteclient != nil {
-		termiteclient.GroupDispatch = !termiteclient.GroupDispatch
-		log.Success("[%t->%t] %s", !termiteclient.GroupDispatch, termiteclient.GroupDispatch, termiteclient.FullDesc())
 	} else {
-		// handle invalid hash
-		log.Error("No such node")
+		// handle the hash represent a termite client
+		termiteclient := context.Ctx.FindTermiteClientByHash(hash)
+		if termiteclient != nil {
+			termiteclient.GroupDispatch = !termiteclient.GroupDispatch
+			log.Success("[%t->%t] %s", !termiteclient.GroupDispatch, termiteclient.GroupDispatch, termiteclient.FullDesc())
+		} else {
+			// handle invalid hash
+			log.Error("No such node")
+		}
 	}
 }
 

--- a/internal/cli/dispatcher/turn.go
+++ b/internal/cli/dispatcher/turn.go
@@ -24,6 +24,10 @@ func (dispatcher commandDispatcher) Turn(args []string) {
 			client.GroupDispatch = !client.GroupDispatch
 			log.Success("[%t->%t] %s", !client.GroupDispatch, client.GroupDispatch, client.FullDesc())
 		}
+		for _, client := range (*server).GetAllTermiteClients() {
+			client.GroupDispatch = !client.GroupDispatch
+			log.Success("[%t->%t] %s", !client.GroupDispatch, client.GroupDispatch, client.FullDesc())
+		}
 		return
 	}
 
@@ -32,6 +36,13 @@ func (dispatcher commandDispatcher) Turn(args []string) {
 	if client != nil {
 		client.GroupDispatch = !client.GroupDispatch
 		log.Success("[%t->%t] %s", !client.GroupDispatch, client.GroupDispatch, client.FullDesc())
+	}
+
+	// handle the hash represent a termite client
+	termiteclient := context.Ctx.FindTermiteClientByHash(hash)
+	if termiteclient != nil {
+		termiteclient.GroupDispatch = !termiteclient.GroupDispatch
+		log.Success("[%t->%t] %s", !termiteclient.GroupDispatch, termiteclient.GroupDispatch, termiteclient.FullDesc())
 	} else {
 		// handle invalid hash
 		log.Error("No such node")

--- a/internal/context/server.go
+++ b/internal/context/server.go
@@ -258,7 +258,7 @@ func (s *TCPServer) AsTable() {
 			s.Hash,
 			(*s).Host,
 			(*s).Port,
-			len((*s).Clients),
+			len((*s).Clients)+len((*s).TermiteClients),
 		))
 
 		t.AppendHeader(table.Row{"Hash", "Network", "OS", "User", "Python", "Time", "Alias", "GroupDispatch"})
@@ -285,7 +285,7 @@ func (s *TCPServer) AsTable() {
 				client.Python2 != "" || client.Python3 != "",
 				humanize.Time(client.TimeStamp),
 				client.Alias,
-				"",
+				client.GroupDispatch,
 			})
 		}
 
@@ -456,6 +456,7 @@ func (s *TCPServer) NotifyWebSocketOnlineTermiteClient(client *TermiteClient) {
 
 // Encrypted clients
 func (s *TCPServer) AddTermiteClient(client *TermiteClient) {
+	client.GroupDispatch = s.GroupDispatch
 	if _, exists := s.TermiteClients[client.Hash]; exists {
 		log.Error("Duplicated income connection detected!")
 

--- a/internal/context/termite.go
+++ b/internal/context/termite.go
@@ -56,6 +56,7 @@ type TermiteClient struct {
 	Python3           string              `json:"python3"`
 	TimeStamp         time.Time           `json:"timestamp"`
 	DisableHistory    bool                `json:"disable_hisory"`
+	GroupDispatch     bool                `json:"group_dispatch"`
 	server            *TCPServer          `json:"-"`
 	encoderLock       *sync.Mutex         `json:"-"`
 	decoderLock       *sync.Mutex         `json:"-"`
@@ -90,6 +91,7 @@ func CreateTermiteClient(conn net.Conn, server *TCPServer, disableHistory bool) 
 		processes:         map[string]*Process{},
 		currentProcessKey: "",
 		DisableHistory:    disableHistory,
+		GroupDispatch:     false,
 	}
 }
 
@@ -485,7 +487,7 @@ func (c *TermiteClient) Close() {
 func (c *TermiteClient) AsTable() {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
-	t.AppendHeader(table.Row{"Hash", "Network", "OS", "User", "Python", "Time", "Alias"})
+	t.AppendHeader(table.Row{"Hash", "Network", "OS", "User", "Python", "Time", "Alias", "GroupDispatch"})
 	t.AppendRow([]interface{}{
 		c.Hash,
 		c.conn.RemoteAddr().String(),
@@ -494,6 +496,7 @@ func (c *TermiteClient) AsTable() {
 		c.Python2 != "" || c.Python3 != "",
 		humanize.Time(c.TimeStamp),
 		c.Alias,
+		c.GroupDispatch,
 	})
 	t.Render()
 }
@@ -567,8 +570,8 @@ func (c *TermiteClient) OnelineDesc() string {
 
 func (c *TermiteClient) FullDesc() string {
 	addr := c.conn.RemoteAddr()
-	return fmt.Sprintf("[%s] %s://%s (connected at: %s) [%s]", c.Hash, addr.Network(), addr.String(),
-		humanize.Time(c.TimeStamp), c.OS.String())
+	return fmt.Sprintf("[%s] %s://%s (connected at: %s) [%s] [%t]", c.Hash, addr.Network(), addr.String(),
+		humanize.Time(c.TimeStamp), c.OS.String(), c.GroupDispatch)
 }
 
 func (c *TermiteClient) AddProcess(key string, process *Process) {


### PR DESCRIPTION
Fixes an issue where the "list" command shows 0 clients online in the header (while showing the correct number of clients in the footer message).

Adds support for DataDispatcher to work for Termite (encrypted) servers.  Works the same as with normal servers.