### PR TITLE
Add timeout to DataDispatcher for Termite clients, add shell_path configuration variable to Platypus server config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ build_termite: prepare
 	echo "Building termite"
 	# echo -e "Building termite_linux_amd64"
 	env GOOS=linux GOARCH=amd64 go build -ldflags="-s -w " -trimpath -o ./build/termite/termite_linux_amd64 cmd/termite/main.go
+	# echo -e "Building termite_linux_arm"
+	env GOOS=linux GOARCH=arm GOARM=5 go build -ldflags="-s -w " -trimpath -o ./build/termite/termite_linux_arm cmd/termite/main.go
 
 collect_assets: build_frontend build_termite
 	echo "Collecting assets files"

--- a/assets/config.example.yml
+++ b/assets/config.example.yml
@@ -12,12 +12,14 @@ servers:
     encrypted: true
     disable_history: true
     public_ip: ""
+    shell_path: "/bin/bash"
   - host: "0.0.0.0"
     port: 13338
     # Using TimeStamp allows us to track all connections from the same IP / Username / OS and MAC.
     hashFormat: "%i %u %m %o %t"
     disable_history: true
     public_ip: ""
+    shell_path: "/bin/bash"
 restful:
   # Because RESTful DO NOT support any authentication mechanism,
   # DO NOT expose the restful server into any external network.

--- a/cmd/platypus/main.go
+++ b/cmd/platypus/main.go
@@ -79,7 +79,7 @@ func main() {
 
 	// Init servers from config file
 	for _, s := range config.Servers {
-		server := context.CreateTCPServer(s.Host, uint16(s.Port), s.HashFormat, s.Encrypted, s.DisableHistory, s.PublicIP)
+		server := context.CreateTCPServer(s.Host, uint16(s.Port), s.HashFormat, s.Encrypted, s.DisableHistory, s.PublicIP, s.ShellPath)
 		if server != nil {
 			// avoid terminal being disrupted
 			time.Sleep(0x100 * time.Millisecond)

--- a/internal/cli/dispatcher/run.go
+++ b/internal/cli/dispatcher/run.go
@@ -23,7 +23,7 @@ func (dispatcher commandDispatcher) Run(args []string) {
 		return
 	}
 
-	server := context.CreateTCPServer(host, uint16(port), "", false, true, "")
+	server := context.CreateTCPServer(host, uint16(port), "", false, true, "", "")
 	if server != nil {
 		go (*server).Run()
 	}

--- a/internal/context/client.go
+++ b/internal/context/client.go
@@ -91,6 +91,10 @@ func (c *TCPClient) GetHashFormat() string {
 	return c.server.hashFormat
 }
 
+func (c *TCPClient) GetShellPath() string {
+	return c.server.ShellPath
+}
+
 func (c *TCPClient) GetConn() net.Conn {
 	return c.conn
 }
@@ -591,8 +595,8 @@ func (c *TCPClient) EstablishPTY() error {
 	}
 
 	// Step 1: Spawn /bin/sh via pty of victim
-	command := "python3 -c 'import pty;pty.spawn(\"/bin/bash\")'"
-	log.Info("spawning /bin/bash on the current client")
+	command := "python3 -c 'import pty;pty.spawn(\"" + c.GetShellPath() + "\")'"
+	log.Info("spawning " + c.GetShellPath() + " on the current client")
 	c.System(command)
 
 	// TODO: Check whether pty is established
@@ -606,7 +610,8 @@ func (c *TCPClient) EstablishPTY() error {
 	log.Info("reseting client terminal...")
 	c.System("reset")
 	log.Info("reseting client SHELL...")
-	c.System("export SHELL=bash")
+	command = fmt.Sprintf("export SHELL=%s", c.GetShellPath())
+	c.System(command)
 	log.Info("reseting client TERM colors...")
 	c.System("export TERM=xterm-256color")
 	log.Info("reseting client window size...")

--- a/internal/context/restful.go
+++ b/internal/context/restful.go
@@ -382,11 +382,7 @@ func CreateRESTfulAPIServer() *gin.Engine {
 					return
 				}
 				encrypted, _ := strconv.ParseBool(c.PostForm("encrypted"))
-				shellpath := c.PostForm("shellpath")
-				if len(shellpath) <= 0 {
-					shellpath = "/bin/bash"
-				}
-				server := CreateTCPServer(c.PostForm("host"), uint16(port), "", encrypted, true, "", shellpath)
+				server := CreateTCPServer(c.PostForm("host"), uint16(port), "", encrypted, true, "", "")
 				if server != nil {
 					go (*server).Run()
 					c.JSON(200, gin.H{

--- a/internal/context/restful.go
+++ b/internal/context/restful.go
@@ -119,7 +119,7 @@ func CreateRESTfulAPIServer() *gin.Engine {
 			// Incase somebody is interacting via cli
 			current.EstablishPTY()
 			// SET_WINDOW_TITLE '1'
-			s.WriteBinary([]byte("1" + "/bin/bash (ubuntu)"))
+			s.WriteBinary([]byte("1" + current.GetShellPath() + " (ubuntu)"))
 			// SET_PREFERENCES '2'
 			s.WriteBinary([]byte("2" + "{ }"))
 
@@ -144,18 +144,18 @@ func CreateRESTfulAPIServer() *gin.Engine {
 		currentTermite := Ctx.FindTermiteClientByHash(hash)
 		if currentTermite != nil {
 			log.Info("Encrypted websocket connected: %s", currentTermite.OnelineDesc())
-			// Start process /bin/bash
+			// Start shell process
 			s.Set("termiteClient", currentTermite)
 
 			// SET_WINDOW_TITLE '1'
-			s.WriteBinary([]byte("1" + "/bin/bash (ubuntu)"))
+			s.WriteBinary([]byte("1" + currentTermite.GetShellPath() + " (ubuntu)"))
 			// SET_PREFERENCES '2'
 			s.WriteBinary([]byte("2" + "{ }"))
 			// OUTPUT '0'
 			key := str.RandomString(0x10)
 			s.Set("key", key)
 
-			currentTermite.RequestStartProcess("/bin/bash", 0, 0, key)
+			currentTermite.RequestStartProcess(currentTermite.GetShellPath(), 0, 0, key)
 
 			// Create Process Object
 			process := Process{
@@ -382,7 +382,11 @@ func CreateRESTfulAPIServer() *gin.Engine {
 					return
 				}
 				encrypted, _ := strconv.ParseBool(c.PostForm("encrypted"))
-				server := CreateTCPServer(c.PostForm("host"), uint16(port), "", encrypted, true, "")
+				shellpath := c.PostForm("host")
+				if len(shellpath) <= 0 {
+					shellpath = "/bin/bash"
+				}
+				server := CreateTCPServer(c.PostForm("host"), uint16(port), "", encrypted, true, "", shellpath)
 				if server != nil {
 					go (*server).Run()
 					c.JSON(200, gin.H{

--- a/internal/context/restful.go
+++ b/internal/context/restful.go
@@ -382,7 +382,7 @@ func CreateRESTfulAPIServer() *gin.Engine {
 					return
 				}
 				encrypted, _ := strconv.ParseBool(c.PostForm("encrypted"))
-				shellpath := c.PostForm("host")
+				shellpath := c.PostForm("shellpath")
 				if len(shellpath) <= 0 {
 					shellpath = "/bin/bash"
 				}

--- a/internal/context/server.go
+++ b/internal/context/server.go
@@ -40,11 +40,12 @@ type TCPServer struct {
 	Encrypted      bool                        `json:"encrypted"`
 	DisableHistory bool                        `json:"disable_history"`
 	PublicIP       string                      `json:"public_ip"`
+	ShellPath      string                      `json:"shell_path"`
 	hashFormat     string                      `json:"-"`
 	stopped        chan struct{}               `json:"-"`
 }
 
-func CreateTCPServer(host string, port uint16, hashFormat string, encrypted bool, disableHistory bool, PublicIP string) *TCPServer {
+func CreateTCPServer(host string, port uint16, hashFormat string, encrypted bool, disableHistory bool, PublicIP string, ShellPath string) *TCPServer {
 	service := fmt.Sprintf("%s:%d", host, port)
 
 	if _, ok := Ctx.Servers[hash.MD5(service)]; ok {
@@ -71,6 +72,7 @@ func CreateTCPServer(host string, port uint16, hashFormat string, encrypted bool
 		Encrypted:      encrypted,
 		DisableHistory: disableHistory,
 		PublicIP:       PublicIP,
+		ShellPath:      ShellPath,
 	}
 
 	Ctx.Servers[hash.MD5(service)] = tcpServer
@@ -97,6 +99,14 @@ func CreateTCPServer(host string, port uint16, hashFormat string, encrypted bool
 		log.Success("Public IP Detected: %s", tcpServer.PublicIP)
 	} else {
 		log.Info("Public IP (%s) is set in config file.", tcpServer.PublicIP)
+	}
+
+	// Use /bin/bash if no ShellPath was specified
+	if tcpServer.ShellPath == "" {
+		log.Info("No ShellPath was specified, using /bin/bash...")
+		tcpServer.ShellPath = "/bin/bash"
+	} else {
+		log.Info("ShellPath (%s) is set in config file.", tcpServer.ShellPath)
 	}
 
 	// Try to check

--- a/internal/context/termite.go
+++ b/internal/context/termite.go
@@ -123,6 +123,10 @@ func (c *TermiteClient) GetHashFormat() string {
 	return c.server.hashFormat
 }
 
+func (c *TermiteClient) GetShellPath() string {
+	return c.server.ShellPath
+}
+
 func (c *TermiteClient) StartSocks5Server() {
 	c.Send(message.Message{
 		Type: message.DYNAMIC_TUNNEL_CREATE,
@@ -306,7 +310,7 @@ func (c *TermiteClient) StartShell() {
 	columns, rows, _ := term.GetSize(0)
 
 	key := str.RandomString(0x10)
-	c.RequestStartProcess("/bin/bash", columns, rows, key)
+	c.RequestStartProcess(c.GetShellPath(), columns, rows, key)
 
 	// Create Process Object
 	process := Process{

--- a/internal/util/config/config.go
+++ b/internal/util/config/config.go
@@ -8,6 +8,7 @@ type Config struct {
 		Encrypted      bool   `yaml:"encrypted"`
 		DisableHistory bool   `yaml:"disable_history"`
 		PublicIP       string `yaml:"public_ip"`
+		ShellPath      string `yaml:"shell_path"`
 	}
 	RESTful struct {
 		Host   string `yaml:"host"`


### PR DESCRIPTION
Hello again!  I apologize for this being submitted to the main branch but it's a direct fix to the PR I recently submitted.  I'll try to get merged into the "dev" branch for future submissions as I noticed some of the other recent ones have been getting pulled into there.

I've been using it further and it turns out if a command gets "stuck" on a Termite client the entire Platypus server gets stuck basically forever.  You can still hit Ctrl+C and press "Y" twice to exit but that's about it.

This PR adds a simple go channel timeout and changes the termite DataDispatcher section (the original one is left alone, that seems to have different ways to handle timeouts as the Termite stuff seems more event driven/websocket).  

`result := client.System(command) <-----Stuck forever if something goes wrong`

to this:

```
// Check for timeout
c1 := make(chan string, 1)
go func() {
	result := client.System(command)
	c1 <- result
}()
select {
case result := <-c1:
	log.Success("%s", result)
case <-time.After(3 * time.Second):
	log.Error("Command timed out %s: %s", client.FullDesc(), command)
}
```

The PR also adds the ShellPath configuration option.  It's completely optional to have in your config file and will default to /bin/bash if it isn't.

You guys are probably better go programmers than me (I'm just copying your style and trying to stay as consistent as I can, literally never used it before but it's getting to the point where the language hardly matters and they seem to change every few years as to what is popular) so feel free to tweak them.  I wasn't sure if there was anything I needed to do with the templates but since a lot of them have a mix of /bin/bash and /bin/sh already the templates are probably fine.

Thanks!