### PR TITLE
Add nil check to prevent interface conversion exception that could occur if ClientInfo.Body was nil

### DIFF
--- a/internal/context/termite.go
+++ b/internal/context/termite.go
@@ -162,27 +162,32 @@ func (c *TermiteClient) GatherClientInfo(hashFormat string) bool {
 	}
 
 	if msg.Type == message.CLIENT_INFO {
-		clientInfo := msg.Body.(*message.BodyClientInfo)
-		c.Version = clientInfo.Version
-		log.Info("Client version: v%s", c.Version)
-		c.OS = oss.Parse(clientInfo.OS)
-		c.User = clientInfo.User
-		c.Python2 = clientInfo.Python2
-		c.Python3 = clientInfo.Python3
-		c.NetworkInterfaces = clientInfo.NetworkInterfaces
-		c.Hash = c.makeHash(hashFormat)
-		if semver.Compare(fmt.Sprintf("v%s", update.Version), fmt.Sprintf("v%s", c.Version)) > 0 {
-			// Termite needs up to date
-			c.Send(message.Message{
-				Type: message.UPDATE,
-				Body: message.BodyUpdate{
-					DistributorURL: Ctx.Distributor.Url,
-					Version:        update.Version,
-				},
-			})
+		if msg.Body != nil {
+			clientInfo := msg.Body.(*message.BodyClientInfo)
+			c.Version = clientInfo.Version
+			log.Info("Client version: v%s", c.Version)
+			c.OS = oss.Parse(clientInfo.OS)
+			c.User = clientInfo.User
+			c.Python2 = clientInfo.Python2
+			c.Python3 = clientInfo.Python3
+			c.NetworkInterfaces = clientInfo.NetworkInterfaces
+			c.Hash = c.makeHash(hashFormat)
+			if semver.Compare(fmt.Sprintf("v%s", update.Version), fmt.Sprintf("v%s", c.Version)) > 0 {
+				// Termite needs up to date
+				c.Send(message.Message{
+					Type: message.UPDATE,
+					Body: message.BodyUpdate{
+						DistributorURL: Ctx.Distributor.Url,
+						Version:        update.Version,
+					},
+				})
+				return false
+			}
+			return true
+		} else {
+			log.Error("Client sent empty client info body", msg)
 			return false
 		}
-		return true
 	} else {
 		log.Error("Client sent unexpected message type: %v", msg)
 		return false

--- a/internal/context/termite.go
+++ b/internal/context/termite.go
@@ -185,7 +185,7 @@ func (c *TermiteClient) GatherClientInfo(hashFormat string) bool {
 			}
 			return true
 		} else {
-			log.Error("Client sent empty client info body", msg)
+			log.Error("Client sent empty client info body: %v", msg)
 			return false
 		}
 	} else {


### PR DESCRIPTION
Hello again!

Everything has been working great with my several Platypus servers except I'm occasionally getting an exception:

```
 panic: interface conversion: interface {} is nil, not *message.BodyClientInfo

goroutine 452 [running]:
github.com/WangYihang/Platypus/internal/context.(*TermiteClient).GatherClientInfo(0xc00011c300, {0xc0003e8270, 0xe})
        github.com/WangYihang/Platypus/internal/context/termite.go:165 +0x66e
github.com/WangYihang/Platypus/internal/context.(*TCPServer).Handle(0xc0000b2e70, {0xccb150?, 0xc00009e380?})
        github.com/WangYihang/Platypus/internal/context/server.go:138 +0xa5
created by github.com/WangYihang/Platypus/internal/context.(*TCPServer).Run
        github.com/WangYihang/Platypus/internal/context/server.go:257 +0x75e
```

Interestingly this has only ever occurred on my server that serves webcams.  My other servers that serve other types of devices have *never* got this crash.  The webcam Platypus server can't run for more than about 24-36 hours before this happens.

It seems like the termite client is sending an empty body but is able to pass this check:

`if msg.Type == message.CLIENT_INFO {`

This does not happen every time on this platform and there's probably an average of 20 or so of these connected at once with the exception occurring every 24-36 hours.  It may only be one bad/corrupted client that does this somewhere in the pool but it takes down the entire Platypus server when it happens.

I ended up adding a simple check like this:

```
if msg.Body != nil {
...
} else {
  log.Error("Client sent empty client info body: %v", msg)
  return false
}
```

This seems to be rare and platform dependent somehow but I figured I'd submit it.  Thank you!