### PR TITLE
fix docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ A modern multiple reverse shell sessions/clients manager via terminal written in
 
 - [x] Multiple service listening port
 - [x] Multiple client connections
-- [x] [RESTful API](./doc/RESTful.md)
+- [x] [RESTful API](./docs/RESTful.md)
 - [x] [Python SDK](https://github.com/WangYihang/Platypus-Python)
-- [x] [Reverse shell as a service](/doc/RaaS.md) (Pop a reverse shell in multiple languages without remembering idle commands)
+- [x] [Reverse shell as a service](/docs/RaaS.md) (Pop a reverse shell in multiple languages without remembering idle commands)
 - [x] Download/Upload file with progress bar
 - [x] Full interactive shell
   - [x] Using vim gracefully in reverse shell


### PR DESCRIPTION
missing 's' in url to docs for restful api