### PR TITLE
fix(ui): toggle-group active state — visible text on visible bg

### DIFF
--- a/desktop/frontend/src/style.css
+++ b/desktop/frontend/src/style.css
@@ -89,8 +89,20 @@
     --color-text-primary: var(--color-text-primary);
     --color-text-secondary: var(--color-text-secondary);
     --color-text-muted: var(--color-text-muted);
-    --color-accent: var(--color-accent);
-    --color-accent-fg: var(--color-accent-fg);
+    /* `--color-accent` is the Tailwind utility shadcn components reach
+       for via `bg-accent` / `text-accent-foreground` (Toggle, Dropdown,
+       FileTable selection, ActivitiesPage hover). Wire it to the
+       shadcn semantic `--accent` (surface-hover dark gray) so the
+       active toggle pill stays visible — pointing it at the raw
+       `--color-accent` (#fafafa) collided with `--accent-foreground`
+       (also white) and rendered the active state as a blank white
+       block. The brand-white token is still available via the JS
+       `palette.accent` export for inline-style consumers, and via
+       `bg-brand` for class-based consumers that genuinely want it.   */
+    --color-accent: var(--accent);
+    --color-accent-fg: var(--accent-foreground);
+    --color-brand: #fafafa;
+    --color-brand-fg: #0a0a0a;
     --color-success: var(--color-success);
     --color-success-dot: var(--color-success-dot);
     --color-danger: var(--color-danger);

--- a/e2e/specs/30-toggle-active-contrast.spec.ts
+++ b/e2e/specs/30-toggle-active-contrast.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "../fixtures/test";
+
+import { loginAsAdmin } from "../fixtures/auth";
+
+// Regression: shadcn ToggleGroup's data-[state=on] state mapped both
+// `bg-accent` and `text-accent-foreground` to the same near-white
+// token via @theme inline collision. Result: white text on white
+// background — the active toggle vanished. Assert background and
+// foreground colours differ wherever a ToggleGroup is rendered active.
+test.describe("toggle-group active state contrast", () => {
+    test("Fleet view-switcher 'Table' toggle has visible text", async ({ page }) => {
+        await loginAsAdmin(page);
+        await page.getByRole("button", { name: /Default created/i }).click();
+        await page.getByRole("link", { name: /Fleet$/ }).click();
+
+        const active = page.getByRole("radio", { name: /Table/ });
+        await expect(active).toHaveAttribute("data-state", "on");
+
+        const colors = await active.evaluate((el) => {
+            const cs = window.getComputedStyle(el);
+            return { bg: cs.backgroundColor, fg: cs.color };
+        });
+        expect(colors.bg).not.toBe(colors.fg);
+    });
+});


### PR DESCRIPTION
## Symptom
Across Fleet (Table/Timeline/Graph), Activities filter, Enrollment, Sessions Live/All — the **active** toggle pill rendered as a blank white block with no visible label.

## Root cause
`@theme inline` re-exposed both:
- `--color-accent: var(--color-accent)` → `#fafafa`
- `--color-accent-foreground: var(--accent-foreground)` → `var(--color-text-primary)` → `#fafafa`

Tailwind's `bg-accent` and `text-accent-foreground` (used by shadcn's `<Toggle>` `data-[state=on]` styling) both resolved to white. White-on-white = invisible.

## Fix
Repoint Tailwind's `--color-accent` to the shadcn semantic `--accent` (surface-hover dark gray). The brand-white token is still available via `palette.accent` (JS) and a new `--color-brand` Tailwind utility for the rare consumer that genuinely wants it.

## Test
`e2e/specs/30-toggle-active-contrast.spec.ts` — visits Fleet, asserts the active `Table` toggle's `getComputedStyle.backgroundColor !== getComputedStyle.color`. Fails before the fix, passes after.

Full suite: 21 passed / 3 skipped, no console-noise regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BY5gWnWuM8B8mamYHsgnHU)_