### PR TITLE
fix(ui): drop stale 'listeners' / 'dispatch' wording from copy

### DIFF
--- a/desktop/frontend/src/pages/ProjectsLanding.tsx
+++ b/desktop/frontend/src/pages/ProjectsLanding.tsx
@@ -27,14 +27,14 @@ export default function ProjectsLanding() {
         <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
             <PageHeader
                 title="Projects"
-                subtitle="Pick a project to inspect its hosts, listeners, and dispatch"
+                subtitle="Pick a project to inspect its fleet and activity"
             />
             <div style={{ flex: 1, overflow: "auto", padding: space[8] }}>
                 {list.length === 0 ? (
                     <EmptyState
                         icon={<FolderOpen className="size-5" />}
                         title="No projects yet"
-                        description="An admin creates projects from the sidebar. Each project groups its own listeners, hosts, sessions, and dispatches."
+                        description="An admin creates projects from the sidebar. Each project scopes its own hosts, sessions, and access."
                     />
                 ) : (
                     <div

--- a/desktop/frontend/src/pages/fleet/HostsPanel.tsx
+++ b/desktop/frontend/src/pages/fleet/HostsPanel.tsx
@@ -123,7 +123,7 @@ export default function HostsPanel() {
                     <EmptyState
                         icon={<Monitor className="size-5" />}
                         title="No hosts yet"
-                        description="Hosts register themselves when an agent connects to one of your listeners. Create a listener first, then run the agent on a target machine."
+                        description="Hosts appear here once an agent enrolls into this project. Issue an install command (or PAT) from Enrollment, then run the agent on the target machine."
                         action={
                             <Button
                                 onClick={() => navigate(`/projects/${project.slug}/enrollment`)}

--- a/e2e/specs/31-stale-listeners-dispatch-copy.spec.ts
+++ b/e2e/specs/31-stale-listeners-dispatch-copy.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "../fixtures/test";
+
+import { loginAsAdmin } from "../fixtures/auth";
+
+// Listeners and Dispatch were removed in the v2 IA refactor (Fleet
+// merged Hosts/Sessions/Topology, Dispatch deleted entirely). Several
+// page subtitles, empty-state descriptions and call-to-action labels
+// still mentioned the dead concepts. This regression guard scans the
+// surfaces that carried the stale wording.
+test.describe("no stale 'listeners' or 'dispatch' copy", () => {
+    test("Projects landing subtitle and empty-state mention neither", async ({
+        page,
+    }) => {
+        await loginAsAdmin(page);
+        await expect(page).toHaveURL(/\/projects$/);
+        await expect(page.getByText("Projects", { exact: true })).toBeVisible();
+
+        const text =
+            (await page.locator('main, [role="main"]').first().textContent()) ?? "";
+        expect(text).not.toMatch(/\blisteners?\b/i);
+        expect(text).not.toMatch(/\bdispatch(es)?\b/i);
+    });
+
+    test("Fleet empty-state on a project with no agents", async ({ page }) => {
+        await loginAsAdmin(page);
+        await page.getByRole("button", { name: /Staging created/i }).click();
+        await page.getByRole("link", { name: /Fleet$/ }).click();
+        await expect(page.getByText("No hosts yet")).toBeVisible();
+
+        const main = page.locator("main");
+        const text = (await main.textContent()) ?? "";
+        expect(text).not.toMatch(/\blisteners?\b/i);
+    });
+});


### PR DESCRIPTION
## Symptom
Three user-visible strings still named retired concepts (Listeners + Dispatch were both removed in the v2 IA refactor):
- `ProjectsLanding` subtitle: *"Pick a project to inspect its hosts, **listeners**, and **dispatch**"*
- `ProjectsLanding` empty-state: *"Each project groups its own **listeners**, hosts, sessions, and **dispatches**."*
- Fleet `HostsPanel` empty-state: *"Hosts register themselves when an agent connects to one of your **listeners**. Create a **listener** first, then run the agent…"*

The Fleet copy also told users to "create a listener" — which is no longer possible at all.

## Fix
Rewrites all three in terms of surfaces that still exist (fleet / activity / enrollment).

## Test
`e2e/specs/31-stale-listeners-dispatch-copy.spec.ts` scans `<main>` text on the Projects landing and the Staging fleet empty-state, asserting neither contains `listeners?` or `dispatch(es)?`. Both checks fail before the fix, pass after. Full suite: 22 passed / 3 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BY5gWnWuM8B8mamYHsgnHU)_