### PR TITLE
build(deps): bump golang.org/x/crypto from 0.51.0 to 0.52.0 in /desktop

### DIFF
--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/wailsapp/go-webview2 v1.0.23 // indirect
 	github.com/wailsapp/mimetype v1.4.1 // indirect
-	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -68,8 +68,8 @@ github.com/wailsapp/wails/v2 v2.12.0 h1:BHO/kLNWFHYjCzucxbzAYZWUjub1Tvb4cSguQozH
 github.com/wailsapp/wails/v2 v2.12.0/go.mod h1:mo1bzK1DEJrobt7YrBjgxvb5Sihb1mhAY09hppbibQg=
 github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/net v0.0.0-20210505024714-0287a6fb4125/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=


### PR DESCRIPTION
Supersedes #340, which has been un-mergeable (`dirty`) and can no longer be rebased by Dependabot — automatic rebases were disabled after the PR sat open for 30+ days.

## Why #340 conflicts

#340 proposed moving four `golang.org/x` deps in `desktop/go.mod` together. Since it was opened, `main` advanced three of them on its own, to versions at or beyond what the PR proposed:

| Dependency | #340 proposed | `main` today | Remaining delta |
| --- | --- | --- | --- |
| `golang.org/x/crypto` | 0.52.0 | 0.51.0 | **needs the bump** |
| `golang.org/x/net` | 0.54.0 | 0.55.0 | already ahead |
| `golang.org/x/sys` | 0.45.0 | 0.45.0 | already equal |
| `golang.org/x/text` | 0.37.0 | 0.37.0 | already equal |

So the conflict resolution collapses to the `x/crypto` bump alone.

## Changes

```diff
-golang.org/x/crypto v0.51.0 // indirect
+golang.org/x/crypto v0.52.0 // indirect
```

Three insertions, three deletions across `desktop/go.mod` and `desktop/go.sum`. Regenerated with `go get golang.org/x/crypto@v0.52.0 && go mod tidy` inside `desktop/` rather than hand-edited; the resulting `go.sum` hashes are identical to the ones Dependabot proposed in #340.

`v0.52.0` carries the `x/crypto/ssh` security fixes: source-address critical-option bypass, an integer-overflow infinite loop on large channel writes, deadlocks on unexpected channel and global responses, a nil-authority-callback panic, and stricter DSA parameter / RSA modulus limits.

## Verification

- `make desktop-test` (what the Desktop workflow's `test` job runs) — all four `desktop/internal/...` packages pass with `-race`
- `go mod verify` in `desktop/` — all modules verified
- `go test ./cmd/platypus-server/...` dependency regression tests pass; `go mod tidy` left the `toolchain go1.25.9` pin in `desktop/go.mod` intact

`go build ./...` in `desktop/` fails on `pattern all:frontend/dist: no matching files found`. That is unrelated to this change — the embedded frontend bundle is not built in this checkout, and CI's `build` job runs `pnpm build` beforehand.

Merging this should let Dependabot close #340 automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C62d8sjpZ1CRprTrcZTYH5)_